### PR TITLE
Add basic speaker plus fuctionality

### DIFF
--- a/StatisticalRobot-Lib/Speaker.cs
+++ b/StatisticalRobot-Lib/Speaker.cs
@@ -1,0 +1,55 @@
+using System.Device.Gpio;
+
+namespace Avans.StatisticalRobot;
+
+public class Speaker
+{
+    private readonly int _pin;
+    private readonly GpioController _gpio;
+
+    public Speaker(int pin)
+    {
+        _pin = pin;
+        _gpio = new GpioController();
+        Initialize();
+    }
+
+    private void Initialize()
+    {
+        _gpio.OpenPin(_pin, PinMode.Output);
+        _gpio.Write(_pin, PinValue.Low);
+    }
+
+    public void PlayNote(int periodMicroseconds, int duration = 100)
+    {
+        if (periodMicroseconds <= 0)
+            return;
+
+        for (int i = 0; i < duration; i++)
+        {
+            _gpio.Write(_pin, PinValue.High);
+            Thread.Sleep(TimeSpan.FromMicroseconds(periodMicroseconds));
+            _gpio.Write(_pin, PinValue.Low);
+            Thread.Sleep(TimeSpan.FromMicroseconds(periodMicroseconds));
+        }
+    }
+
+    public void PlaySequence(int[] notePeriods, int delayBetweenNotes = 500)
+    {
+        foreach (int period in notePeriods)
+        {
+            PlayNote(period);
+            Thread.Sleep(delayBetweenNotes);
+        }
+    }
+
+    public void Silence()
+    {
+        _gpio.Write(_pin, PinValue.Low);
+    }
+
+    public void Dispose()
+    {
+        _gpio.Dispose();
+    }
+}

--- a/StatisticalRobot-LibTest/Program.cs
+++ b/StatisticalRobot-LibTest/Program.cs
@@ -54,6 +54,10 @@ Robot.Motors(0, 0);
 
 RGBSensor rgbSensor = new RGBSensor(RGBSensor.DEFAULT_I2C_ADDRESS, RGBSensor.IntegrationTime.INTEGRATION_TIME_700MS, RGBSensor.Gain.GAIN_1X);
 
+//Speaker plus test
+Speaker speaker = new Speaker(26);
+int[] bassNotes = { 1911, 1702, 1516, 1431, 1275, 1136, 1012 };
+speaker.PlaySequence(bassNotes);
 // De hoofdlus van het programma, deze blijft zich herhalen.
 while (true)
 {


### PR DESCRIPTION
Basic functionaliteit voor de speaker plus actuator 

- Component die werkend is met deze pr: [LINK](https://wiki.seeedstudio.com/Grove-Speaker-Plus/)
- Speaker kan aan de hand van notes die aangegeven worden deze of los afspelen of in een sequence.

Voorbeeld
`Speaker speaker = new Speaker(26); //init speaker op pin 26 `
`int[] bassNotes = { 1911, 1702, 1516, 1431, 1275, 1136, 1012 }; //add notes voor speaker om te spelen`
`speaker.PlaySequence(bassNotes); //speel in sequence`

Indien aanpassingen gemaakt moeten worden laat het graag weten.
